### PR TITLE
Bug 1649737 - Add a toolchain task to repack the custom Android NDK used to build B2G r=glandium

### DIFF
--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -56,6 +56,24 @@ linux64-android-ndk-linux-repack:
         toolchain-artifact: project/gecko/android-ndk/android-ndk.tar.zst
         toolchain-alias: android-ndk-linux
 
+linux64-android-ndk-b2g-linux-repack:
+    description: "Custom Android NDK (Linux) for Boot2Gecko repack toolchain build"
+    treeherder:
+        symbol: TL(android-ndk-b2g-linux)
+    worker:
+        artifacts:
+            - name: project/gecko/android-ndk
+              path: /builds/worker/project/gecko/android-ndk/
+              type: directory
+        env:
+            LOCAL_NDK_BASE_URL: "ftp://ftp.kaiostech.com/ndk/android-ndk"
+    run:
+        script: repack-android-ndk-linux.sh
+        resources:
+            - 'python/mozboot/**/*android*'
+        toolchain-artifact: project/gecko/android-ndk/android-ndk.tar.zst
+        toolchain-alias: android-ndk-b2g-linux
+
 linux64-android-gradle-dependencies:
     description: "Android Gradle dependencies toolchain task"
     treeherder:


### PR DESCRIPTION
Differential Revision: https://phabricator.services.mozilla.com/D81852