### PR TITLE
Support mach install for b2g.

### DIFF
--- a/b2g/build.mk
+++ b/b2g/build.mk
@@ -11,8 +11,11 @@ package:
 	@$(MAKE) -C b2g/installer
 
 install::
-	@echo 'B2G can't be installed directly.'
-	@exit 1
+	@adb shell stop b2g
+	@adb remount
+	@adb shell rm -rf /system/b2g
+	@adb push dist/b2g/ /system/b2g
+	@adb shell start b2g
 
 upload::
 	@$(MAKE) -C b2g/installer upload

--- a/python/mozbuild/mozbuild/base.py
+++ b/python/mozbuild/mozbuild/base.py
@@ -1011,10 +1011,20 @@ class MachCommandConditions(object):
         return False
 
     @staticmethod
+    def is_b2g(cls):
+        """Must have a B2G build."""
+        if hasattr(cls, 'substs'):
+            return ((cls.substs.get('MOZ_BUILD_APP') == 'b2g') and
+                    (cls.substs.get('MOZ_WIDGET_TOOLKIT') == 'gonk'))
+        return False
+
+
+    @staticmethod
     def has_build(cls):
         """Must have a build."""
         return (MachCommandConditions.is_firefox_or_android(cls) or
                 MachCommandConditions.is_thunderbird(cls) or
+                MachCommandConditions.is_b2g(cls) or
                 MachCommandConditions.is_b2g_desktop(cls))
 
     @staticmethod


### PR DESCRIPTION
In the future we'll probably want to add a separate AdbDevice for
b2g that would handle installing, but for now this works.