### PR TITLE
Fix emulator CI build break.part2

### DIFF
--- a/b2g/config/mozconfigs/common
+++ b/b2g/config/mozconfigs/common
@@ -95,6 +95,7 @@ ac_add_options --with-wifi-1.1-so="$MOZ_FETCHES_DIR/b2g-sysroot/out/target/produ
 ac_add_options --with-wifi-1.2-so="$MOZ_FETCHES_DIR/b2g-sysroot/out/target/product/generic_x86_64/system/lib64/android.hardware.wifi@1.2.so"
 ac_add_options --with-wifi-1.3-so="$MOZ_FETCHES_DIR/b2g-sysroot/out/target/product/generic_x86_64/system/lib64/android.hardware.wifi@1.3.so"
 ac_add_options --with-wificond-so="$MOZ_FETCHES_DIR/b2g-sysroot/out/target/product/generic_x86_64/system/lib64/libwificond_ipc_shared.so"
+ac_add_options --with-mtp-so="$MOZ_FETCHES_DIR/b2g-sysroot/out/target/product/generic_x86_64/system/lib64/libmtp.so"
 
 export CFLAGS="-Wno-nullability-completeness"
 

--- a/taskcluster/scripts/misc/build-b2g-emulator.sh
+++ b/taskcluster/scripts/misc/build-b2g-emulator.sh
@@ -203,7 +203,8 @@ out/target/product/generic_x86_64/system/lib64/libutils.so
 out/target/product/generic_x86_64/system/lib64/libvold_binder_shared.so
 out/target/product/generic_x86_64/system/lib64/libwificond_ipc_shared.so
 out/target/product/generic_x86_64/system/lib64/netd_aidl_interface-V2-cpp.so
-out/target/product/generic_x86_64/system/lib64/netd_event_listener_interface-V1-cpp.so"
+out/target/product/generic_x86_64/system/lib64/netd_event_listener_interface-V1-cpp.so
+out/target/product/generic_x86_64/system/lib64/libmtp.so"
 
 copy_to_sysroot_full_path "${LIBRARIES}"
 


### PR DESCRIPTION
1. Add options "--with-mtp-so" to b2g/config/mozconfigs/common
2. Add libmtp.so to b2g-sysroot