### PR TITLE
Bug 1673825 - Speed up the script that creates the Boot2Gecko sysroot r=gerard-majax

### DIFF
--- a/taskcluster/ci/fetch/kaios.yml
+++ b/taskcluster/ci/fetch/kaios.yml
@@ -15,3 +15,17 @@ b2g-manifests:
         type: git
         repo: https://github.com/kaiostech/manifests/
         revision: 7632d5806dd1ea54dbfb6b507043691fa16998ca
+
+gonk-misc:
+    description: Random parts that make gonk work
+    fetch:
+        type: git
+        repo: https://github.com/kaiostech/gonk-misc/
+        revision: 687e699f092a774e4cf8bf443ef7d5212d62a7aa
+
+api-daemon:
+    description: Rust daemons to access various native services
+    fetch:
+        type: git
+        repo: https://github.com/kaiostech/api-daemon/
+        revision: af6c738d6832ce39ca1fef2fc06154f214f82398

--- a/taskcluster/ci/toolchain/b2g-emulator.yml
+++ b/taskcluster/ci/toolchain/b2g-emulator.yml
@@ -23,8 +23,10 @@ linux64-b2g-build:
             - 'taskcluster/scripts/misc/create-b2g-sysroot.sh'
     fetches:
         fetch:
+            - api-daemon
             - B2G
             - b2g-manifests
+            - gonk-misc
         toolchain:
             - android-ndk-b2g-linux
             - linux64-rust-android

--- a/taskcluster/scripts/misc/build-b2g-emulator.sh
+++ b/taskcluster/scripts/misc/build-b2g-emulator.sh
@@ -17,6 +17,8 @@ git add .
 git commit -m dummy
 
 # Configure the emulator build and fetch all the AOSP dependencies
+mv "${MOZ_FETCHES_DIR}/gonk-misc" "${MOZ_FETCHES_DIR}/B2G/"
+mv "${MOZ_FETCHES_DIR}/api-daemon" "${MOZ_FETCHES_DIR}/B2G/gonk-misc/"
 cd "${MOZ_FETCHES_DIR}/B2G"
 GITREPO="${MOZ_FETCHES_DIR}/manifests" REPO_SYNC_FLAGS="-j4" REPO_INIT_FLAGS="--depth=1" ./config.sh emulator-10-x86_64
 
@@ -87,33 +89,6 @@ index c2e3147..7df775f 100644
  
  .PHONY: buildsymbols
  buildsymbols:
-EOF
-
-# Work around the hardcoded LOCAL_NDK variable
-patch -d gonk-misc/api-daemon -p1 <<'EOF'
-diff --git a/Android.mk b/Android.mk
-index afaa48f..72a5636 100644
---- a/Android.mk
-+++ b/Android.mk
-@@ -40,7 +40,11 @@ API_DAEMON_LIB_DEPS := \
- 
- include $(BUILD_PREBUILT)
- 
-+ifndef ANDROID_NDK
- LOCAL_NDK := $(HOME)/.mozbuild/android-ndk-r20b-canary
-+else
-+LOCAL_NDK := $(ANDROID_NDK)
-+endif
- 
- $(LOCAL_BUILT_MODULE): $(TARGET_CRTBEGIN_DYNAMIC_O) $(TARGET_CRTEND_O) $(addprefix $(TARGET_OUT_SHARED_LIBRARIES)/,$(API_DAEMON_LIB_DEPS))
- 	@echo "api-daemon: $(API_DAEMON_EXEC)"
-@@ -88,4 +92,4 @@ ifneq ($(PREBUILT_CA_BUNDLE),)
- 	@cp $(PREBUILT_CA_BUNDLE) -f $@
- else
- 	@perl $(MK_CA_BUNDLE) -d $(CERTDATA_FILE) -f $@
--endif
-\ No newline at end of file
-+endif
 EOF
 
 # Force compressing debug symbols


### PR DESCRIPTION
This cuts down rsync invocations to just two by letting it read inputs
from a (generated) file and giving it the appropriate flags. It also
simplifies the file lists by placing every entry on a separate line
and removes redundant files that were already present.

Differential Revision: https://phabricator.services.mozilla.com/D94946