### PR TITLE
Bug 1653198 - Implement bootstraping Boot2Gecko r=glandium

### DIFF
--- a/b2g/config/mozconfigs/common
+++ b/b2g/config/mozconfigs/common
@@ -67,16 +67,6 @@ ac_add_options --disable-sandbox
 ac_add_options --enable-linker=lld
 ac_add_options --disable-elf-hack
 
-export CFLAGS="-Wno-nullability-completeness"
-
-export CPPFLAGS="-DANDROID -DTARGET_OS_GONK \
--DJE_FORCE_SYNC_COMPARE_AND_SWAP_4=1 \
--D_USING_LIBCXX \
--DGR_GL_USE_NEW_SHADER_SOURCE_SIGNATURE=1 \
--isystem $ANDROID_NDK/platforms/$ANDROID_PLATFORM/$ARCH_DIR/usr/include"
-
-export LDFLAGS="--sysroot=$MOZ_FETCHES_DIR/android-ndk/platforms/android-29/arch-x86_64/"
-
 ###############################################################################
 ###############################################################################
 ###############################################################################

--- a/b2g/config/mozconfigs/gonk/debug
+++ b/b2g/config/mozconfigs/gonk/debug
@@ -6,7 +6,6 @@ ac_add_options --enable-debug
 # Android
 ac_add_options --with-android-version=29
 ac_add_options --target=x86_64-linux-android
-ac_add_options --with-target-arch-name=x86_64
 
 export MOZILLA_OFFICIAL=1
 

--- a/b2g/config/mozconfigs/gonk/nightly
+++ b/b2g/config/mozconfigs/gonk/nightly
@@ -3,7 +3,6 @@
 # Android
 ac_add_options --with-android-version=29
 ac_add_options --target=x86_64-linux-android
-ac_add_options --with-target-arch-name=x86_64
 
 export MOZILLA_OFFICIAL=1
 

--- a/b2g/moz.configure
+++ b/b2g/moz.configure
@@ -27,20 +27,6 @@ def b2g_os_name(value):
 set_config("MOZ_B2G_OS_NAME", b2g_os_name)
 set_define("MOZ_B2G_OS_NAME", b2g_os_name)
 
-option(
-    "--with-target-arch-name",
-    nargs=1,
-    help="Target arch name for the hidl generated headers",
-)
-
-
-@depends_if("--with-target-arch-name")
-def target_arch_name(value):
-    return value[0]
-
-
-set_config("TARGET_ARCH_NAME", target_arch_name)
-set_define("TARGET_ARCH_NAME", target_arch_name)
 
 option("--with-gonk", nargs=1, help="Path to the gonk base directory")
 option("--with-gonk-gfx", nargs=0, help="Use the gonk widget layer")

--- a/build-b2g.sh
+++ b/build-b2g.sh
@@ -121,8 +121,6 @@ export CROSS_TOOLCHAIN_LINKER_PATH=${CROSS_TOOLCHAIN_LINKER_PATH=:-$GONK_PATH/pr
 
 export PATH=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$GONK_PATH/prebuilts/linux-x86_64/bin/:$CLANG_PATH:$PYTHON_PATH:$CROSS_TOOLCHAIN_LINKER_PATH:$PATH
 
-SYSROOT=$ANDROID_NDK/platforms/$ANDROID_PLATFORM/$ARCH_DIR/
-
 export GONK_PRODUCT=$GONK_PRODUCT_NAME
 
 # Create the sysroot
@@ -141,16 +139,6 @@ taskcluster/scripts/misc/create-b2g-sysroot.sh "${GONK_PATH}" "${SYSROOT_DEST}"
 
 rustc --version
 
-export CFLAGS="-Wno-nullability-completeness"
-
-export CPPFLAGS="-DANDROID -DTARGET_OS_GONK \
--DJE_FORCE_SYNC_COMPARE_AND_SWAP_4=1 \
--D_USING_LIBCXX \
--DGR_GL_USE_NEW_SHADER_SOURCE_SIGNATURE=1 \
--isystem $ANDROID_NDK/platforms/$ANDROID_PLATFORM/$ARCH_DIR/usr/include"
-
 export ANDROID_PLATFORM=$ANDROID_PLATFORM
-
-export LDFLAGS="--sysroot=${SYSROOT}"
 
 ./mach build $@

--- a/mozconfig-b2g
+++ b/mozconfig-b2g
@@ -80,7 +80,6 @@ else
 TARGET_CPU_VARIANT="_$TARGET_CPU_VARIANT"
 fi
 
-ac_add_options --with-target-arch-name="${TARGET_ARCH}${TARGET_ARCH_VARIANT}${TARGET_CPU_VARIANT}"
 ac_add_options --target-build-variant="$TARGET_BUILD_VARIANT"
 if [ "$TARGET_BUILD_VARIANT" != "user" ] ; then
 ENABLE_MARIONETTE=1

--- a/python/mozboot/mozboot/b2g.py
+++ b/python/mozboot/mozboot/b2g.py
@@ -1,0 +1,48 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this,
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import errno
+import os
+import stat
+import subprocess
+import sys
+
+B2G_MOZCONFIG_TEMPLATE = """
+# Build Boot2Gecko
+ac_add_options --enable-application=b2g
+ac_add_options --with-app-basename=b2g
+
+# Android
+ac_add_options --with-android-version=29
+ac_add_options --target=x86_64-linux-android
+
+# Compiler options
+ac_add_options --with-android-ndk="$HOME/.mozbuild/android-ndk-r20b-canary"
+
+# B2G-specific options
+ac_add_options --with-gonk-gfx
+ac_add_options --with-gonk="$HOME/.mozbuild/b2g-sysroot/"
+ac_add_options --enable-b2g-camera
+ac_add_options --enable-b2g-ril
+ac_add_options --enable-b2g-fm
+ac_add_options --enable-forkserver
+
+# Only for x86-64
+ac_add_options --enable-wasm-simd
+
+# Sandbox & profiler are not supported yet
+ac_add_options --disable-profiling
+ac_add_options --disable-sandbox
+
+# Compiler/Linker options
+
+# Since we use lld we need to disable elf-hack
+ac_add_options --enable-linker=lld
+ac_add_options --disable-elf-hack
+"""
+
+def generate_mozconfig():
+    return B2G_MOZCONFIG_TEMPLATE.strip()

--- a/python/mozboot/mozboot/b2g_sysroot.py
+++ b/python/mozboot/mozboot/b2g_sysroot.py
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+LINUX_B2G_SYSROOT = "linux64-b2g-sysroot"

--- a/python/mozboot/mozboot/base.py
+++ b/python/mozboot/mozboot/base.py
@@ -282,6 +282,27 @@ class BaseBootstrapper(object):
             % __name__
         )
 
+    def install_b2g_packages(self, mozconfig_builder):
+        """
+        Install packages required to build Boot2Gecko (application 'b2g').
+        """
+        raise NotImplementedError(
+            "Cannot bootstrap Boot2Gecko: "
+            "%s does not yet implement install_b2g_packages()" % __name__
+        )
+
+    def generate_b2g_mozconfig(self):
+        """
+        Print a message to the console detailing what the user's mozconfig
+        should contain.
+
+        Boot2Gecko currently requires a few specific flags set for the build to
+        work. In time these should be phased out.
+        """
+        raise NotImplementedError(
+            "%s does not yet implement generate_b2g_mozconfig()" % __name__
+        )
+
     def ensure_mach_environment(self, checkout_root):
         mach_binary = os.path.abspath(os.path.join(checkout_root, "mach"))
         if not os.path.exists(mach_binary):

--- a/python/mozboot/mozboot/bootstrap.py
+++ b/python/mozboot/mozboot/bootstrap.py
@@ -69,6 +69,7 @@ Your choice: """
 
 APPLICATIONS = OrderedDict(
     [
+        ("Boot2Gecko", "b2g"),
         ("Firefox for Desktop Artifact Mode", "browser_artifact_mode"),
         ("Firefox for Desktop", "browser"),
         ("GeckoView/Firefox for Android Artifact Mode", "mobile_android_artifact_mode"),
@@ -304,7 +305,7 @@ class Bootstrapper(object):
 
         return state_dir
 
-    def maybe_install_private_packages_or_exit(self, state_dir, checkout_root):
+    def maybe_install_private_packages_or_exit(self, state_dir, checkout_root, application):
         # Install the clang packages needed for building the style system, as
         # well as the version of NodeJS that we currently support.
         # Also install the clang static-analysis package by default
@@ -321,6 +322,8 @@ class Bootstrapper(object):
             self.instance.ensure_lucetc_packages(state_dir, checkout_root)
             self.instance.ensure_wasi_sysroot_packages(state_dir, checkout_root)
             self.instance.ensure_dump_syms_packages(state_dir, checkout_root)
+            if application == "b2g":
+                self.instance.ensure_b2g_sysroot_packages(state_dir, checkout_root)
 
     def check_telemetry_opt_in(self, state_dir):
         # Don't prompt if the user already has a setting for this value.
@@ -408,7 +411,7 @@ class Bootstrapper(object):
 
         if self.instance.no_system_changes:
             self.check_telemetry_opt_in(state_dir)
-            self.maybe_install_private_packages_or_exit(state_dir, checkout_root)
+            self.maybe_install_private_packages_or_exit(state_dir, checkout_root, application)
             self._output_mozconfig(application, mozconfig_builder)
             sys.exit(0)
 
@@ -448,7 +451,7 @@ class Bootstrapper(object):
                 )
 
         self.check_telemetry_opt_in(state_dir)
-        self.maybe_install_private_packages_or_exit(state_dir, checkout_root)
+        self.maybe_install_private_packages_or_exit(state_dir, checkout_root, application)
         self.check_code_submission(checkout_root)
 
         print(FINISHED % name)

--- a/python/mozboot/mozboot/linux_common.py
+++ b/python/mozboot/mozboot/linux_common.py
@@ -174,7 +174,32 @@ class MobileAndroidBootstrapper(object):
         return self.generate_mobile_android_mozconfig(artifact_mode=True)
 
 
+class Boot2GeckoSysrootInstall(object):
+    def __init__(slef, **kwargs):
+        pass
+
+    def install_b2g_packages(self, mozconfig_builder):
+        from mozboot import android
+
+        android.ensure_android(
+            "linux", ndk_only=False, no_interactive=self.no_interactive
+        )
+
+    def ensure_b2g_sysroot_packages(self, state_dir, checkout_root):
+        from mozboot import b2g_sysroot
+
+        self.install_toolchain_artifact(
+            state_dir, checkout_root, b2g_sysroot.LINUX_B2G_SYSROOT
+        )
+
+    def generate_b2g_mozconfig(self, artifact_mode=False):
+        from mozboot import b2g
+
+        return b2g.generate_mozconfig()
+
+
 class LinuxBootstrapper(
+    Boot2GeckoSysrootInstall,
     ClangStaticAnalysisInstall,
     FixStacksInstall,
     DumpSymsInstall,

--- a/taskcluster/ci/toolchain/b2g-emulator.yml
+++ b/taskcluster/ci/toolchain/b2g-emulator.yml
@@ -45,6 +45,8 @@ linux64-b2g-emulator:
             - linux64-b2g-build
 
 linux64-b2g-sysroot:
+    attributes:
+        local-toolchain: true
     treeherder:
         symbol: TL(b2g-sysroot)
     worker-type: b-linux

--- a/taskcluster/taskgraph/util/verify.py
+++ b/taskcluster/taskgraph/util/verify.py
@@ -438,17 +438,17 @@ def verify_local_toolchains(task, taskgraph, scratch_pad, graph_config, paramete
     """
     Toolchains that are used for local development need to be built on a
     level-3 branch to installable via `mach bootstrap`. We ensure here that all
-    such tasks run on at least trunk projects, even if they aren't pulled in as
-    a dependency of other tasks in the graph.
+    such tasks run on at least trunk projects or in the kaios project, even if
+    they aren't pulled in as a dependency of other tasks in the graph.
 
     There is code in `mach artifact toolchain` that verifies that anything
     installed via `mach bootstrap` has the attribute set.
     """
     if task and task.attributes.get("local-toolchain"):
         run_on_projects = task.attributes.get("run_on_projects", [])
-        if not any(alias in run_on_projects for alias in ["all", "trunk"]):
+        if not any(alias in run_on_projects for alias in ["all", "trunk", "kaios"]):
             raise Exception(
-                "Toolchain {} used for local development is not built on trunk. {}".format(
+                "Toolchain {} used for local development is not built on trunk or in the kaios project. {}".format(
                     task.label, run_on_projects
                 )
             )

--- a/widget/gonk/nativewindow/GonkBufferQueueO/GonkConsumerBase.cpp
+++ b/widget/gonk/nativewindow/GonkBufferQueueO/GonkConsumerBase.cpp
@@ -23,11 +23,12 @@
 
 #define EGL_EGLEXT_PROTOTYPES
 
-#include <cutils/atomic.h>
 #include <hardware/hardware.h>
 
 #include <utils/Log.h>
 #include <utils/String8.h>
+
+#include "mozilla/Atomics.h"
 
 #include "GonkConsumerBase.h"
 
@@ -35,8 +36,8 @@ namespace android {
 
 // Get an ID that's unique within this process.
 static int32_t createProcessUniqueId() {
-  static volatile int32_t globalCounter = 0;
-  return android_atomic_inc(&globalCounter);
+  static mozilla::Atomic<int32_t, mozilla::Relaxed> counter(0);
+  return counter++;
 }
 
 GonkConsumerBase::GonkConsumerBase(


### PR DESCRIPTION
The current implementation is limited to Linux as we don't support building on
macOS and Windows for the time being. This patch also simplifies the default
configuration by removing unnecessary CPPFLAGS and LDFLAGS additions, and
getting rid of the --with-target-arch-name configure option which was needed
when we didn't have a proper sysroot.

Differential Revision: https://phabricator.services.mozilla.com/D96722