### PR TITLE
Disable search indexing of macOS builds, this implicitly disables the remaining macOS toolchain tasks

### DIFF
--- a/taskcluster/taskgraph/target_tasks.py
+++ b/taskcluster/taskgraph/target_tasks.py
@@ -1061,7 +1061,6 @@ def target_tasks_searchfox(full_task_graph, parameters, graph_config):
     """Select tasks required for indexing Firefox for Searchfox web site each day"""
     return [
         "searchfox-linux64-searchfox/debug",
-        "searchfox-macosx64-searchfox/debug",
         "searchfox-win64-searchfox/debug",
         "searchfox-android-armv7-searchfox/debug",
         "source-test-file-metadata-bugzilla-components",


### PR DESCRIPTION
... and hopefully fixes the decision task on the kaios branch